### PR TITLE
adds the new construct __STACKTRACE__

### DIFF
--- a/old_versions/elixir_1.6.x.lang
+++ b/old_versions/elixir_1.6.x.lang
@@ -26,7 +26,7 @@
 
  GtkSourceView Syntax highlighting for the Elixir programming language
 
- Covers Elixir 1.8.x
+ Covers Elixir 1.6.x
 
 -->
 
@@ -249,7 +249,6 @@
         <keyword>__MODULE__</keyword>
         <keyword>__aliases__</keyword>
         <keyword>__block__</keyword>
-        <keyword>__STACKTRACE__</keyword>
       </context>
 
       <context id="kernel" style-ref="builtin-name">


### PR DESCRIPTION
So, after reading the [Elixir v1.7 release](https://elixir-lang.org/blog/2018/07/25/elixir-v1-7-0-released/) I've noticed only the new ```__STACKTRACE__``` as [new feature](https://elixir-lang.org/blog/2018/07/25/elixir-v1-7-0-released/#the-__stacktrace__-construct) that needed to be added.
Since I do not have a big background with elixir, or GTKSourceView files, I belive that's pretty much what's needed to upgrade this source view to [v1.8 version](https://elixir-lang.org/blog/2019/01/14/elixir-v1-8-0-released/).
I'm sending this pull request in order to request your viewsource [to be added by default](https://github.com/elementary/code/issues/539) at [elementary os](https://elementary.io/pt_BR/), thus it's default [IDE](https://github.com/elementary/code) supports elixir syntax highlight.